### PR TITLE
Fetching Articles requires a locale

### DIFF
--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -2229,10 +2229,10 @@ class AccessPolicyApi(Api):
 class SectionApi(HelpCentreApiBase, CRUDApi, TranslationApi, SubscriptionApi,
                  AccessPolicyApi):
     @extract_id(Section)
-    def articles(self, section):
+    def articles(self, section, locale='en-us'):
         return self._query_zendesk(self.endpoint.articles,
                                    'article',
-                                   id=section)
+                                   id=section, locale=locale)
 
     def create(self, section):
         return CRUDRequest(self).post(section,


### PR DESCRIPTION
https://support.zendesk.com/hc/en-us/community/posts/5609287554586-BUG-Get-articles-by-section-ID-requires-locale